### PR TITLE
Fix conditional rules edit functionality

### DIFF
--- a/js/conditionalRules.js
+++ b/js/conditionalRules.js
@@ -723,8 +723,6 @@ function backToConditionalRules() {
 // Export functions to global scope
 window.renderConditionalRulesTable = renderConditionalRulesTable;
 window.initializeRuleEditor = initializeRuleEditor;
-window.initializeRuleEditorDirect = initializeRuleEditorDirect;
-window.editExistingRuleDirect = editExistingRuleDirect;
 window.showCreateNewRule = showCreateNewRule;
 window.toggleRuleStatus = toggleRuleStatus;
 window.deleteConditionalRule = deleteConditionalRule;
@@ -744,6 +742,5 @@ window.hideAddRuleValueInput = hideAddRuleValueInput;
 window.handleRuleConditionalValueEnter = handleRuleConditionalValueEnter;
 window.addNewRuleConditionalValue = addNewRuleConditionalValue;
 window.backToConditionalRules = backToConditionalRules;
-window.backToConditionalRulesDirect = backToConditionalRulesDirect;
 
 console.log('Conditional rules module loaded and functions exported globally');

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -25,6 +25,7 @@ const ROUTES = {
 // Current navigation state
 let currentRoute = null;
 let navigationInitialized = false;
+let lastProcessedHash = '';
 
 // Initialize hash-based navigation
 function initializeNavigation() {


### PR DESCRIPTION
- Declare lastProcessedHash variable in navigation.js to prevent errors
- Remove exports of undefined functions from conditionalRules.js

This fixes the issue where clicking the edit icon was bringing up the create form instead of editing the existing rule.